### PR TITLE
`RigidMap` compatibility

### DIFF
--- a/src/HashedLocators.jl
+++ b/src/HashedLocators.jl
@@ -8,15 +8,15 @@ using Adapt,KernelAbstractions
     - `lower::SVector{2,T}:` bottom corner of the hash in ξ-space
     - `step::T:` ξ-resolution of the hash
 
-Type to preform efficient and fairly stable `locate`ing on parametric curves. Root=finding can be very 
-unstable for general parametric curves. This is mitigated by supplying a close initial `uv` guess by 
+Type to preform efficient and fairly stable `locate`ing on parametric curves. Root=finding can be very
+unstable for general parametric curves. This is mitigated by supplying a close initial `uv` guess by
 interpolating `hash` before calling `refine`.
 
 ----
 
     HashedLocator(curve,lims;t⁰=0,step=1,buffer=2,T=Float32,mem=Array)
 
-Creates HashedLocator by sampling the curve and finding the bounding box. This box is expanded by the amount `buffer`. 
+Creates HashedLocator by sampling the curve and finding the bounding box. This box is expanded by the amount `buffer`.
 The hash array is allocated to span the box with resolution `step` and initialized using `update!(::,curve,t⁰,samples)`.
 
 Example:
@@ -86,7 +86,7 @@ update!(l::HashedLocator,curve,t,samples=l.lims)=(_update!(get_backend(l.hash),6
         dᵢ = dis2(uvᵢ)
         dᵢ<d && (uv=uvᵢ; d=dᵢ)
     end
-    
+
     # Refine estimate once
     l.hash[I] = l.refine(uv,x,t;itmx=1)
 end
@@ -103,7 +103,7 @@ function (l::HashedLocator)(x,t;fastd²=Inf)
     hash_index = (x-l.lower)/l.step .+ 1
     clamped = clamp.(hash_index,1,size(l.hash))
 
-    # Get hashed parameter 
+    # Get hashed parameter
     uv = l.hash[round.(Int,clamped)...]
 
     # Return it if index is outside domain. Otherwise, refine estimate
@@ -118,10 +118,9 @@ Creates a `ParametericBody` with `locate=HashedLocator(curve,lims...)`.
 function HashedBody(curve,lims::Tuple;T=Float32,map=dmap,kwargs...)
     # Wrap in type safe functions (GPUs are picky)
     wcurve(u::U,t::T) where {U,T} = SVector{2,promote_type(U,T)}(curve(u,t))
-    wmap(x::SVector{n,X},t::T) where {n,X,T} = SVector{n,promote_type(X,T)}(map(x,t))
 
     locate = HashedLocator(wcurve,T.(lims);T,kwargs...)
-    ParametricBody(wcurve,locate;map=wmap,T,kwargs...)
+    ParametricBody(wcurve,locate;map=map,T,kwargs...)
 end
 Adapt.adapt_structure(to, x::ParametricBody{T,L}) where {T,L<:HashedLocator} =
     ParametricBody(x.curve,x.dotS,adapt(to,x.locate),x.map,x.scale,x.half_thk,x.boundary)

--- a/src/LinAlg.jl
+++ b/src/LinAlg.jl
@@ -4,7 +4,7 @@ import Base: \
 @inline function (\)(a::SMatrix{2,3}, b::SVector{2})
     # columns of a'
     a1,a2 = a[1,:],a[2,:]
-    
+
     # Q,R decomposition
     r11 = norm(a1)
     q1 = a1/r11
@@ -17,6 +17,6 @@ import Base: \
     v1 = b[1]/r11
     v2 = (b[2]-r12*v1)/r22
 
-    # return solution x = Qv 
+    # return solution x = Qv
     return q1*v1+q2*v2
 end

--- a/src/NurbsCurves.jl
+++ b/src/NurbsCurves.jl
@@ -6,7 +6,7 @@ using StaticArrays
 Define a non-uniform rational B-spline curve.
 - `pnts`: A 2D array representing the control points of the NURBS curve
 - `knots`: A 1D array of th knot vector of the NURBS curve
-- `wgts`: A 1D array of the wight of the pnts of the NURBS curve 
+- `wgts`: A 1D array of the wight of the pnts of the NURBS curve
 - `d`: The degree of the NURBS curve
 - `n`: the spacial dimension of the NURBS curve, n ∈ {2,3}
 """
@@ -76,11 +76,11 @@ end
 """
     interpNurbs(pnts{D,n};p=n-1)
 
-Given a `SMatrix{D ∈ [2,3],n}` of points, fits a `NurbsCurve{D,n}` of degree `p` to 
+Given a `SMatrix{D ∈ [2,3],n}` of points, fits a `NurbsCurve{D,n}` of degree `p` to
 this set of points. By default the highest degrees NURBS is constructed.
 """
 function interpNurbs(pnts::SMatrix{D,n,T};p=n-1) where {D,n,T}
-    @assert p <= n - 1 "Invalid interpolation: the degree should be less than the number of control points minus 1."    
+    @assert p <= n - 1 "Invalid interpolation: the degree should be less than the number of control points minus 1."
     # construct the parameter and the knot vector
     s = _u(pnts)
     knot = SA{T}[[zeros(p+1); [sum(s[j:j+p-1])/p for j ∈ p-1:n-p]; ones(p+1)]...]

--- a/src/NurbsLocator.jl
+++ b/src/NurbsLocator.jl
@@ -24,7 +24,7 @@ function notC¹(l::NurbsLocator{C},uv) where C<:NurbsCurve{n,d} where {n,d}
     d==1 && return any(uv.≈l.curve.knots) # straight line spline is not C¹ at any knot
     # Assuming we don't have repeated knots, ends are the only remaining potential not C¹ locations
     low,high = first(l.curve.knots),last(l.curve.knots)
-    (uv≈low || uv≈high) ? !l.C¹end : false 
+    (uv≈low || uv≈high) ? !l.C¹end : false
 end
 function eachside(l::NurbsLocator,uv,s=√eps(typeof(uv)))
     low,high = first(l.curve.knots),last(l.curve.knots)
@@ -37,7 +37,7 @@ lims(b::ParametricBody{T,L}) where {T,L<:NurbsLocator} = (first(b.curve.knots),l
 
 Estimate the parameter value `u⁺ = argmin_u (x-l.curve(u))²` for a NURBS in two steps
 1. The nearest point `u` on the `degree=1` version of the curve is found. Return this if degree==1.
-2. Otherwse `refine` this guess until converged or the square distance ≥ `fastd²`. 
+2. Otherwse `refine` this guess until converged or the square distance ≥ `fastd²`.
 """
 function (l::NurbsLocator{C})(x,t;fastd²=Inf) where C<:NurbsCurve{N,degree} where {N,degree}
     # Closest parameter on linear NURBS

--- a/src/ParametricBodies.jl
+++ b/src/ParametricBodies.jl
@@ -1,25 +1,32 @@
 module ParametricBodies
 
 using StaticArrays,ForwardDiff
-import WaterLily: AbstractBody,measure,sdf,interp
+import WaterLily: AbstractBody,measure,sdf,interp,RigidMap,velocity
 
 abstract type AbstractParametricBody <: AbstractBody end
 """
     d,n,V = measure(body::AbstractParametricBody,x,t)
 
-Determine the geometric properties of the body at time `t` closest to 
+Determine the geometric properties of the body at time `t` closest to
 point `x`. Both `dot(curve)` and `dot(map)` contribute to `V` if defined.
 """
 function measure(body::AbstractParametricBody,x,t;fastd²=Inf)
     # curve props and velocity in ξ-frame
     d,n,dotS = curve_props(body,x,t;fastd²)
     d^2 > fastd² && return d,zero(x),zero(x)
+    # if we are close, measure everything
+    return (d,normal_velocity(body.map,n/body.scale,dotS,x,t)...)
+end
+# For generic map
+function normal_velocity(map::Function,n,dotS,x,t)
     dξdt = dotS-ForwardDiff.derivative(t->body.map(x,t),t)
-
     # Convert to x-frame with dξ/dx⁻¹ (d has already been scaled)
     dξdx = ForwardDiff.jacobian(x->body.map(x,t),x)
-    return (d,dξdx\n/body.scale,dξdx\dξdt)
+    return dξdx\n,dξdx\dξdt
 end
+# for RigidMap
+normal_velocity(map::RigidMap,n,dotS,x,t) = n,dotS+velocity(map,x,t)
+
 """
     d = sdf(body::AbstractParametricBody,x,t)
 
@@ -32,14 +39,14 @@ sdf(body::AbstractParametricBody,x,t;fastd²=0) = curve_props(body,x,t;fastd²)[
     ParametricBody{T::Real}(curve,locate) <: AbstractBody
 
     - `curve(u,t)` parametrically defined curve
-    - `dotS(u,t)=derivative(t->curve(u,t),t)` time derivative of curve 
+    - `dotS(u,t)=derivative(t->curve(u,t),t)` time derivative of curve
     - `locate(ξ,t)` method to find nearest parameter `u` to `ξ`
     - `map(x,t)=x` mapping from `x` to `ξ`
     - `thk=0` thickness offset for the signed distance
     - `boundary=true` if the curve represent a body boundary, not a space-curve
 
-Explicitly defines a geometry by an unsteady parametric curve. The curve is currently limited 
-to be univariate, and must wind counter-clockwise if closed. The optional `dotS`, `map`, 
+Explicitly defines a geometry by an unsteady parametric curve. The curve is currently limited
+to be univariate, and must wind counter-clockwise if closed. The optional `dotS`, `map`,
 `thk` and `boundary` parameters allow for more general geometry embeddings.
 
 Example:
@@ -62,7 +69,7 @@ struct ParametricBody{T,L<:Function,S<:Function,dS<:Function,M<:Function,dT<:Fun
     map::M      #ξ = map(x,t)
     scale::T    #|dx/dξ| = scale
     half_thk::dT #half thickness
-    boundary::Bool 
+    boundary::Bool
 end
 # Default functions
 import LinearAlgebra: det
@@ -91,7 +98,7 @@ function curve_props(body::ParametricBody,x,t;fastd²=Inf)
     else # outward = towards p
         notC¹(body.locate,u) ? hat(p) : align(p,hat(tangent(body.curve,u,t)))
     end
-    
+
     # Get scaled & thinkess adjusted distance and dot(S)
     return (body.scale*p'*n-body.half_thk(u),n,body.dotS(u,t))
 end

--- a/src/ParametricBodies.jl
+++ b/src/ParametricBodies.jl
@@ -1,7 +1,7 @@
 module ParametricBodies
 
 using StaticArrays,ForwardDiff
-import WaterLily: AbstractBody,measure,sdf,interp,RigidMap,velocity
+import WaterLily: AbstractBody,measure,sdf,velocity
 
 abstract type AbstractParametricBody <: AbstractBody end
 """
@@ -11,22 +11,14 @@ Determine the geometric properties of the body at time `t` closest to
 point `x`. Both `dot(curve)` and `dot(map)` contribute to `V` if defined.
 """
 function measure(body::AbstractParametricBody,x,t;fastd²=Inf)
-    # curve props and velocity in ξ-frame
+    # Get curve props and check for fast exit
     d,n,dotS = curve_props(body,x,t;fastd²)
     d^2 > fastd² && return d,zero(x),zero(x)
-    # if we are close, measure everything
-    return (d,normal_velocity(body.map,n/body.scale,dotS,x,t)...)
-end
-# For generic map
-function normal_velocity(map::Function,n,dotS,x,t)
-    dξdt = dotS-ForwardDiff.derivative(t->body.map(x,t),t)
+
     # Convert to x-frame with dξ/dx⁻¹ (d has already been scaled)
     dξdx = ForwardDiff.jacobian(x->body.map(x,t),x)
-    return dξdx\n,dξdx\dξdt
+    return (d, dξdx\n/body.scale, dξdx\dotS + velocity(body.map,x,t))
 end
-# for RigidMap
-normal_velocity(map::RigidMap,n,dotS,x,t) = n,dotS+velocity(map,x,t)
-
 """
     d = sdf(body::AbstractParametricBody,x,t)
 

--- a/src/ParametricBodies.jl
+++ b/src/ParametricBodies.jl
@@ -11,13 +11,14 @@ Determine the geometric properties of the body at time `t` closest to
 point `x`. Both `dot(curve)` and `dot(map)` contribute to `V` if defined.
 """
 function measure(body::AbstractParametricBody,x,t;fastd²=Inf)
-    # Get curve props and check for fast exit
+    # curve props and velocity in ξ-frame
     d,n,dotS = curve_props(body,x,t;fastd²)
     d^2 > fastd² && return d,zero(x),zero(x)
+    dξdt = dotS-ForwardDiff.derivative(t->body.map(x,t),t)
 
     # Convert to x-frame with dξ/dx⁻¹ (d has already been scaled)
     dξdx = ForwardDiff.jacobian(x->body.map(x,t),x)
-    return (d, dξdx\n/body.scale, dξdx\dotS + velocity(body.map,x,t))
+    return (d,dξdx\n/body.scale,dξdx\dξdt)
 end
 """
     d = sdf(body::AbstractParametricBody,x,t)

--- a/src/PlanarBodies.jl
+++ b/src/PlanarBodies.jl
@@ -2,8 +2,8 @@
     PlanarBody(curve::NurbsCurve;map)       # creates NurbsLocator
     PlanarBody(curve,lims::Tuple;T,map,mem) # creates HashedLocator
 
-Embeds a ParametricBody onto the `ζ₃=0` plane defined by `map`. The `curve` 
-defines the planform of a planar body with minimial thickness `thk=ϵ+√3/2`. 
+Embeds a ParametricBody onto the `ζ₃=0` plane defined by `map`. The `curve`
+defines the planform of a planar body with minimial thickness `thk=ϵ+√3/2`.
 See Lauber & Weymouth 2022. Note, the velocity is defined soley from `dot(map)`.
 """
 struct PlanarBody{T,P<:ParametricBody,F<:Function} <: AbstractParametricBody
@@ -15,21 +15,17 @@ end
 function PlanarBody(curve,lims::Tuple;T=Float32,map=dmap,thk=T(√3+2),kwargs...)
     # Wrap in type safe functions (GPUs are picky)
     wcurve(u::U,t::T) where {U,T} = SVector{2,promote_type(U,T)}(curve(u,t))
-    wmap(x::SVector{n,X},t::T) where {n,X,T} = SVector{n,promote_type(X,T)}(map(x,t))
 
     scale = T(ParametricBodies.get_scale(map,SA{T}[0,0,0]))
     locate = HashedLocator(wcurve,T.(lims);T,step=inv(scale),kwargs...)
     planform = ParametricBody(wcurve,locate)
-    PlanarBody(planform,wmap,scale,T(thk/2))
+    PlanarBody(planform,map,scale,T(thk/2))
 end
 Adapt.adapt_structure(to, x::PlanarBody) = PlanarBody(adapt(to,x.planform),x.map,x.scale,x.half_thk)
 
 function PlanarBody(curve::NurbsCurve;map=dmap,T=eltype(curve.pnts),thk=T(√3+2))
-    # Wrap in type safe function (GPUs are picky)
-    wmap(x::SVector{n,X},t::T) where {n,X,T} = SVector{n,promote_type(X,T)}(map(x,t))
-
     scale = T(ParametricBodies.get_scale(map,SA{T}[0,0,0]))
-    PlanarBody(ParametricBody(curve),wmap,scale,T(thk/2))
+    PlanarBody(ParametricBody(curve),map,scale,T(thk/2))
 end
 
 function curve_props(body::PlanarBody{T},x::SVector{3},t;fastd²=Inf) where T

--- a/src/Refine.jl
+++ b/src/Refine.jl
@@ -5,7 +5,7 @@ Returns a `function(u₀,x,t)` which finds `u⁺ = argmin(d²(u)=|curve(u,t)-x|�
 
     d²′ = (curve(u⁺,t)-x)'*tangent(curve,u⁺,t) = 0
 
-starting from an initial guess `u₀`. The function attempts to Newton step to the root, falling back on 
+starting from an initial guess `u₀`. The function attempts to Newton step to the root, falling back on
 gradient descent if `d²′′<0`. The resulting minimizer respects `u⁺ ∈ lims` and `closed` curves.
 
     Note: A good inital guess `u₀` is critical for robustly finding the _global_ minimizer.


### PR DESCRIPTION
This PR make `ParametricBodies.jl` compatible with the `RigidMap` PR https://github.com/WaterLily-jl/WaterLily.jl/pull/266.

The test fail for now since we haven't commited PR#266 yet.