### PR TITLE
Improve NURBS locator

### DIFF
--- a/src/NurbsCurves.jl
+++ b/src/NurbsCurves.jl
@@ -46,7 +46,7 @@ Evaluate the NURBS curve
 - `s` : A float, representing the position along the spline where we want to compute the value of that NURBS
 - `t` : time is currently unused but needed for ParametricBodies
 """
-function (l::NurbsCurve{n,d})(u::T,t=0)::SVector where {T,d,n}
+function (l::NurbsCurve{n,d})(u::T,t=0) where {T,d,n}
     pt = zeros(SVector{n,T}); wsum=T(0.0)
     for k in 1:size(l.pnts, 2)
         l.knots[k]>u && break

--- a/src/NurbsLocator.jl
+++ b/src/NurbsLocator.jl
@@ -14,7 +14,7 @@ end
 function NurbsLocator(curve::NurbsCurve)
     low,high = first(curve.knots),last(curve.knots)
     C¹end = curve(low)≈curve(high) && tangent(curve,low,0)≈tangent(curve,high,0) # closed C¹ curve?
-    NurbsLocator(curve,C¹end,refine(curve,(low,high),false))
+    NurbsLocator(curve,C¹end,refine(curve,(low,high),false,length(curve.wgts)-1))
 end
 Adapt.adapt_structure(to, x::NurbsLocator) = NurbsLocator(x.curve,x.C¹end,x.refine)
 

--- a/src/NurbsLocator.jl
+++ b/src/NurbsLocator.jl
@@ -1,8 +1,8 @@
 """
-    NurbsLocator(curve::NurbsCurve)
+    NurbsLocator(curve::NurbsCurve) => (::NurbsLocator)(x,t;fastd²=Inf) => u⁺ = argmin_u |x-curve(u,t)|²
 
-NURBS-specific locator function. Loops through the spline sections, to find an inital guess
-based on the `degree=1` (straight-line) version, and then refine. Unlike `HashedLocator`
+NURBS-specific locator function. Loops through the spline sections, finds an inital guess
+based on the `degree=1` (straight-line) version, and then `refine`s. Unlike `HashedLocator`
 this locator doesn't need to be initialized.
 """
 struct NurbsLocator{C<:NurbsCurve,F<:Function} <: AbstractLocator
@@ -14,7 +14,7 @@ end
 function NurbsLocator(curve::NurbsCurve)
     low,high = first(curve.knots),last(curve.knots)
     C¹end = curve(low)≈curve(high) && tangent(curve,low,0)≈tangent(curve,high,0) # closed C¹ curve?
-    NurbsLocator(curve,C¹end,refine(curve,(low,high),C¹end))
+    NurbsLocator(curve,C¹end,refine(curve,(low,high),false))
 end
 Adapt.adapt_structure(to, x::NurbsLocator) = NurbsLocator(x.curve,x.C¹end,x.refine)
 
@@ -32,27 +32,22 @@ function eachside(l::NurbsLocator,uv,s=√eps(typeof(uv)))
 end
 
 lims(b::ParametricBody{T,L}) where {T,L<:NurbsLocator} = (first(b.curve.knots),last(b.curve.knots))
-"""
-    (l::NurbsLocator)(x,t;fastd²=Inf)
 
-Estimate the parameter value `u⁺ = argmin_u (x-l.curve(u))²` for a NURBS in two steps
-1. The nearest point `u` on the `degree=1` version of the curve is found. Return this if degree==1.
-2. Otherwse `refine` this guess until converged or the square distance ≥ `fastd²`. 
-"""
 function (l::NurbsLocator{C})(x,t;fastd²=Inf) where C<:NurbsCurve{N,degree} where {N,degree}
-    # Closest parameter on linear NURBS
-    pnts = l.curve.pnts; n = size(pnts,2)-1
-    b = pnts[:,1]; u,d² = zero(eltype(pnts)),sum(abs2,x-b)
+    pnts = l.curve.pnts; n = size(pnts,2)-1; T = eltype(pnts)
+    b = pnts[:,1]; u = zero(T); d² = sum(abs2,x-l.curve(u,t))
     for i in 1:n                        # Loop through segments
         a = b; b = pnts[:,i+1]               # segment a-to-b
         a==b && continue                     # skip zero length segments
         s = b-a                              # tangent vector
-        p = clamp(((x-a)'*s)/(s'*s),0,1)     # perp distance along s
+        p = clamp(((x-a)'*s)/(s's),0,1)      # perp distance along s
         uᵢ,d²ᵢ = (i-1+p)/n,sum(abs2,x-a-s*p) # segment minimizer
+        if degree>1                          # refine on curve
+            uᵢ = l.refine(uᵢ,x,t;fastd²,lims=(i-1,i)./T(n))
+            d²ᵢ = sum(abs2,x-l.curve(uᵢ,t))
+        end
         d²ᵢ<d² && (u=uᵢ;d²=d²ᵢ)              # update if uᵢ is closests
-    end
-    # Return if degree=1, otherwise refine
-    degree == 1 ? u : l.refine(u,x,t;fastd²)
+    end; u
 end
 """
     ParametricBody(curve::NurbsCurve;kwargs...)

--- a/src/Refine.jl
+++ b/src/Refine.jl
@@ -16,10 +16,10 @@ gradient descent if `d²′′<0`. The resulting minimizer respects `u⁺ ∈ li
     - `stpmn=stpmx/100`: Minimum step size before the loop will exit
     - `stpmd=stpmx/10`: Step size below which `d² ≥ fastd²` will exit the loop
 """
-function refine(curve,lims,closed)::Function
+function refine(curve,lims,closed,steps=20)::Function
     align(u,x,t) = (curve(u,t)-x)'*tangent(curve,u,t)
     dalign(u,x,t) = ForwardDiff.derivative(u->align(u,x,t),u)
-    stpmx=(lims[2]-lims[1])/20
+    stpmx=(lims[2]-lims[1])/steps
     return function(u::T,x,t;fastd²=Inf,itmx=10,lims=lims,stpmn=stpmx/100,stpmd=stpmx/10) where T
         for _ in 1:itmx
             u₀,a,da = u,align(u,x,t),dalign(u,x,t)

--- a/src/Refine.jl
+++ b/src/Refine.jl
@@ -19,7 +19,8 @@ gradient descent if `d²′′<0`. The resulting minimizer respects `u⁺ ∈ li
 function refine(curve,lims,closed)::Function
     align(u,x,t) = (curve(u,t)-x)'*tangent(curve,u,t)
     dalign(u,x,t) = ForwardDiff.derivative(u->align(u,x,t),u)
-    return function(u::T,x,t;fastd²=Inf,itmx=10,stpmx=(lims[2]-lims[1])/20,stpmn=stpmx/100,stpmd=stpmx/10) where T
+    stpmx=(lims[2]-lims[1])/20
+    return function(u::T,x,t;fastd²=Inf,itmx=10,lims=lims,stpmn=stpmx/100,stpmd=stpmx/10) where T
         for _ in 1:itmx
             u₀,a,da = u,align(u,x,t),dalign(u,x,t)
             step = da < eps(T) ? -copysign(stpmx,a) : -clamp(a/da,-stpmx,stpmx)


### PR DESCRIPTION
The previous locator function assumed the linear projection would give a good initial guess for the global minimizer. Unfortunately, this can break for non-convex shapes and high curvative regions. The updated code refines each segment's local minimizer, ensuring a more accurate result at the cost of some additional computation.